### PR TITLE
docs: fix title typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Analytics Connect-Objects Plugin
+# Analytics Connected-Objects Plugin
 
 [![npm](https://badgen.net/npm/v/plugin-analytics-connected-objects)](https://badgen.net/npm/v/plugin-analytics-connected-objects)
 [![downloads](https://badgen.net/npm/dw/plugin-analytics-connected-objects)](https://badgen.net/npm/dw/plugin-analytics-connected-objects)


### PR DESCRIPTION
Title "Connect**ed**-objects", **ed** was missing