### PR TITLE
ci: version upgrade for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plugin-analytics-connected-objects",
   "description": "Additional Salesforce CLI commands to manage CRM Analytics connected-objects",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "dependencies": {
     "@oclif/core": "^2.9.4",
     "@oclif/plugin-legacy": "^1.3.0",


### PR DESCRIPTION
Version upgrade due to:
- Cannot publish over previously published version \"0.0.1\"."