### PR TITLE
fix: postinstall script removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,6 @@
     "docs": "sf-docs",
     "format": "wireit",
     "lint": "wireit",
-    "postinstall": "yarn husky install",
     "postpack": "shx rm -f oclif.manifest.json oclif.lock",
     "prepack": "sf-prepack",
     "test": "wireit",


### PR DESCRIPTION
When installing the @1.1.2 version the `postinstall` script was causing issues